### PR TITLE
allow provider registry.terraform.io/hashicorp/time

### DIFF
--- a/policy/approved_providers.rego
+++ b/policy/approved_providers.rego
@@ -4,6 +4,7 @@ deny[msg] {
     resource_change := input.resource_changes[_]
     resource_change.provider_name != "registry.terraform.io/hashicorp/aws"
     resource_change.provider_name != "registry.terraform.io/hashicorp/random"
+    resource_change.provider_name != "registry.terraform.io/hashicorp/time"
     resource_change.provider_name != "registry.terraform.io/hashicorp/azurerm"
     resource_change.provider_name != "registry.terraform.io/hashicorp/azuread"
     resource_change.provider_name != "registry.terraform.io/microsoft/azuredevops"


### PR DESCRIPTION
This provider has time-based resources which can introduce delays or prevent perpetual differences caused by the `timestamp()` function

I have a use case with an azure module where (presumably due to a bug in the provider) there must be a delay between destroying a resource and destroying a subnet delegated to that resource